### PR TITLE
[DBスキーマとシードデータが自動投入される] 実装完了

### DIFF
--- a/ai_generated/HANDOVER.md
+++ b/ai_generated/HANDOVER.md
@@ -1,0 +1,68 @@
+# HANDOVER
+
+## 技術スタック
+- フロントエンド: Next.js 14 (App Router, TypeScript), shadcn/ui + Tailwind CSS
+- バックエンド: Spring Boot 3.x, Java 21 LTS, Spring MVC, Spring Data JPA
+- DB: PostgreSQL 16 + Flyway (マイグレーション管理)
+- IdP: KeyCloak (OIDC)
+- BFF: Next.js API Routes + NextAuth.js
+- APIドキュメント: springdoc-openapi
+
+## ディレクトリ構成
+```
+output_system/
+├── docker-compose.yml          # 全4サービス統合起動
+├── frontend/
+│   ├── Dockerfile              # ubuntu:24.04, Node.js 20, マルチステージ
+│   ├── package.json
+│   ├── .npmrc                  # min-release-age=7 (サプライチェーン対策)
+│   ├── next.config.mjs         # standalone出力 (注: .ts不可, .mjsを使用)
+│   ├── tailwind.config.ts
+│   └── src/app/                # App Router pages
+├── backend/
+│   ├── Dockerfile              # ubuntu:24.04, Java 21, マルチステージ
+│   ├── pom.xml                 # Spring Boot 3.4.x, Flyway, JPA含む
+│   └── src/main/
+│       ├── java/com/example/paas/
+│       │   ├── PaasApplication.java
+│       │   ├── model/
+│       │   │   ├── User.java           # usersテーブル対応エンティティ
+│       │   │   └── CloudAccess.java    # cloud_accessテーブル対応エンティティ
+│       │   └── repository/
+│       │       ├── UserRepository.java
+│       │       └── CloudAccessRepository.java
+│       └── resources/
+│           ├── application.yml
+│           └── db/migration/
+│               ├── V1__init.sql    # users/cloud_accessテーブル定義
+│               └── V2__seed.sql    # 初期シードデータ
+└── keycloak/
+    └── realm-export.json       # realmテンプレート
+```
+
+## ビルド・起動方法
+```bash
+cd output_system
+docker compose build
+docker compose up -d
+```
+
+## 設計判断
+- next.config.mjs採用: Next.js 14はnext.config.tsを未サポート。.mjs形式を使用すること
+- マルチステージビルド: フロント/バックともにマルチステージでイメージサイズ削減
+- standalone出力: Next.jsのoutput: "standalone"でDocker向けに最適化
+- KeyCloak healthcheck: curlがKeyCloakコンテナに未インストール。/dev/tcpで代替
+- KeyCloak port 8081: ホスト8080はphpmyadminが使用中。8081:8080でマッピング
+- ビルドコンテキスト: ssl-certificates/がルート階層のためdocker-compose.ymlのcontextを`..`に設定
+- JPA ddl-auto=validate: Flywayでスキーマ管理するためHibernateのDDL自動生成は無効化、差異検出のみ
+- cloud_accessシードはCROSS JOIN+WHERE: user_idを事前に知らずINSERT可能。employee_idで結合してuser_idを解決
+
+## はまりポイント
+- KeyCloakにcurlがない: healthcheckで`/bin/sh`の`/dev/tcp`を使ってTCP接続確認
+- Port 8080/3001/3002は別プロジェクト(dataagent)が使用中: 環境制約、設定は正しい
+- next.config.tsはNext.js 14未対応: `.mjs`にリネームが必要
+- PostgreSQLのTIMESTAMP型: application.ymlのJPA設定はLocalDateTime型との対応。TIMESTAMP WITH TIME ZONEではなくTIMESTAMP（タイムゾーンなし）を使用
+
+## 実装済み機能
+- PBI #4: docker compose upで全4サービス（frontend/backend/postgres/keycloak）が起動する基盤
+- PBI #5: DBスキーマとシードデータ自動投入（Flyway V1/V2, JPA Entity/Repository）

--- a/output_system/backend/src/main/java/com/example/paas/model/CloudAccess.java
+++ b/output_system/backend/src/main/java/com/example/paas/model/CloudAccess.java
@@ -1,0 +1,104 @@
+package com.example.paas.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+/**
+ * クラウドアクセスエンティティ
+ *
+ * <p>ユーザーのクラウドサービス（AWS/GCP/Azure）へのアクセス権を表すJPAエンティティ。
+ * cloud_accessテーブル（db.mdのテーブル定義）に対応する。</p>
+ *
+ * <p>1ユーザーにつきAWS・GCP・Azureの各1件、計3件のレコードを持つことを想定する。
+ * (user_id, cloud_provider)の複合ユニーク制約により重複を防ぐ。</p>
+ */
+@Entity
+@Table(
+    name = "cloud_access",
+    uniqueConstraints = {
+        // (user_id, cloud_provider)の複合ユニーク制約（db.mdの仕様に準拠）
+        @UniqueConstraint(
+            name = "uq_cloud_access_user_provider",
+            columnNames = {"user_id", "cloud_provider"}
+        )
+    }
+)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CloudAccess {
+
+    /**
+     * サロゲートキー（BIGSERIALで自動採番）
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * アクセス権を持つユーザー
+     *
+     * <p>Userエンティティへの多対一関連。
+     * user_idカラムを外部キーとして使用する。
+     * 遅延ロードで関連するユーザー情報を取得する。</p>
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    /**
+     * クラウドプロバイダー名
+     * 取りうる値: "AWS", "GCP", "Azure"
+     */
+    @Column(name = "cloud_provider", nullable = false, length = 20)
+    private String cloudProvider;
+
+    /**
+     * アクセス権の有効/無効フラグ
+     * trueの場合、当該クラウドへのアクセスが許可されている
+     * デフォルトはfalse（無効）
+     */
+    @Column(name = "is_enabled", nullable = false)
+    @Builder.Default
+    private boolean isEnabled = false;
+
+    /**
+     * レコード作成日時
+     * INSERT時に自動設定される
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * レコード最終更新日時
+     * INSERT時・UPDATE時に自動設定される
+     */
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /**
+     * INSERT前にcreatedAt・updatedAtを自動設定する
+     */
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    /**
+     * UPDATE前にupdatedAtを自動更新する
+     */
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/output_system/backend/src/main/java/com/example/paas/model/User.java
+++ b/output_system/backend/src/main/java/com/example/paas/model/User.java
@@ -1,0 +1,127 @@
+package com.example.paas.model;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * ユーザーエンティティ
+ *
+ * <p>PaaS管理ポータルのシステム利用者（社員）情報を表すJPAエンティティ。
+ * usersテーブル（db.mdのテーブル定義）に対応する。</p>
+ *
+ * <p>KeyCloakで認証されたユーザーのDB側情報（部署・役職・管理者フラグ等）を管理する。
+ * Cloud接続情報はCloudAccessエンティティで管理する。</p>
+ *
+ * <ul>
+ *   <li>employee_id: 社員ID（KeyCloakのサブジェクト等と対応させる想定）</li>
+ *   <li>is_admin: trueの場合、管理者として全ユーザーのcloud_accessを閲覧・更新可能</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    /**
+     * サロゲートキー（BIGSERIALで自動採番）
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 社員ID
+     * 一意制約あり。例: E001, E002
+     * 業務上の識別子として使用する
+     */
+    @Column(name = "employee_id", nullable = false, unique = true, length = 50)
+    private String employeeId;
+
+    /**
+     * 氏名
+     */
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    /**
+     * メールアドレス
+     * KeyCloakのユーザーと対応するアドレスを設定する
+     */
+    @Column(name = "email", nullable = false, length = 255)
+    private String email;
+
+    /**
+     * 部署名
+     * 任意項目。未設定の場合はnull
+     */
+    @Column(name = "department", length = 100)
+    private String department;
+
+    /**
+     * 役職
+     * 任意項目。未設定の場合はnull
+     */
+    @Column(name = "position", length = 100)
+    private String position;
+
+    /**
+     * 管理者フラグ
+     * trueの場合、管理者として全ユーザーのアクセス権管理が可能
+     * デフォルトはfalse（一般社員）
+     */
+    @Column(name = "is_admin", nullable = false)
+    @Builder.Default
+    private boolean isAdmin = false;
+
+    /**
+     * レコード作成日時
+     * INSERT時に自動設定される
+     */
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    /**
+     * レコード最終更新日時
+     * INSERT時・UPDATE時に自動設定される
+     */
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    /**
+     * このユーザーが持つクラウドアクセス権リスト
+     *
+     * <p>CloudAccessエンティティのuser_idカラムで双方向関連を構築する。
+     * FetchType.LAZYを指定してN+1問題を回避する。</p>
+     */
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<CloudAccess> cloudAccesses;
+
+    /**
+     * INSERT前にcreatedAt・updatedAtを自動設定する
+     */
+    @PrePersist
+    protected void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        this.createdAt = now;
+        this.updatedAt = now;
+    }
+
+    /**
+     * UPDATE前にupdatedAtを自動更新する
+     */
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/output_system/backend/src/main/java/com/example/paas/repository/CloudAccessRepository.java
+++ b/output_system/backend/src/main/java/com/example/paas/repository/CloudAccessRepository.java
@@ -1,0 +1,43 @@
+package com.example.paas.repository;
+
+import com.example.paas.model.CloudAccess;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * クラウドアクセスリポジトリ
+ *
+ * <p>cloud_accessテーブルへのCRUD操作を提供するSpring Data JPAリポジトリ。
+ * CrudRepositoryを継承することで、基本的なCRUD操作が自動的に実装される。</p>
+ *
+ * <p>主にユーザーのクラウドアクセス権の一覧取得・更新に使用される。</p>
+ */
+@Repository
+public interface CloudAccessRepository extends CrudRepository<CloudAccess, Long> {
+
+    /**
+     * ユーザーIDに紐づくクラウドアクセス権リストを取得する
+     *
+     * <p>ユーザーのダッシュボード表示やアクセス権一覧取得に使用する。
+     * 通常、AWS/GCP/Azureの3件が返される。</p>
+     *
+     * @param userId 検索するユーザーのID
+     * @return 該当するクラウドアクセス権リスト
+     */
+    List<CloudAccess> findByUserId(Long userId);
+
+    /**
+     * ユーザーIDとクラウドプロバイダー名でアクセス権を取得する
+     *
+     * <p>(user_id, cloud_provider)に複合ユニーク制約があるため、結果は0件または1件。
+     * 特定ユーザーの特定クラウドへのアクセス権を確認・更新する際に使用する。</p>
+     *
+     * @param userId         検索するユーザーのID
+     * @param cloudProvider  検索するクラウドプロバイダー名（例: "AWS"）
+     * @return 該当するクラウドアクセス権。存在しない場合はOptional.empty()
+     */
+    Optional<CloudAccess> findByUserIdAndCloudProvider(Long userId, String cloudProvider);
+}

--- a/output_system/backend/src/main/java/com/example/paas/repository/UserRepository.java
+++ b/output_system/backend/src/main/java/com/example/paas/repository/UserRepository.java
@@ -1,0 +1,53 @@
+package com.example.paas.repository;
+
+import com.example.paas.model.User;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * ユーザーリポジトリ
+ *
+ * <p>usersテーブルへのCRUD操作を提供するSpring Data JPAリポジトリ。
+ * CrudRepositoryを継承することで、基本的なCRUD操作（findById, save, delete等）が
+ * 自動的に実装される。</p>
+ *
+ * <p>カスタムクエリメソッドはメソッド名からSpring Data JPAがSQLを自動生成する
+ * （例: findByEmployeeId → SELECT * FROM users WHERE employee_id = ?）。</p>
+ */
+@Repository
+public interface UserRepository extends CrudRepository<User, Long> {
+
+    /**
+     * 社員IDでユーザーを検索する
+     *
+     * <p>ログイン時やAPI呼び出し時に社員IDでユーザーを特定するために使用する。
+     * employee_idにはUNIQUE制約があるため、結果は0件または1件になる。</p>
+     *
+     * @param employeeId 検索する社員ID（例: "E001"）
+     * @return 該当するユーザー。存在しない場合はOptional.empty()
+     */
+    Optional<User> findByEmployeeId(String employeeId);
+
+    /**
+     * メールアドレスでユーザーを検索する
+     *
+     * <p>KeyCloakのトークンに含まれるメールアドレスでDBユーザーを特定するために使用する。
+     * emailには NOT NULL 制約のみ（UNIQUEではない）があるが、実運用では一意を期待する。</p>
+     *
+     * @param email 検索するメールアドレス（例: "tanaka.admin@example.com"）
+     * @return 該当するユーザー。存在しない場合はOptional.empty()
+     */
+    Optional<User> findByEmail(String email);
+
+    /**
+     * 管理者フラグでユーザーリストを検索する
+     *
+     * <p>管理者一覧または一般社員一覧を取得するために使用する。</p>
+     *
+     * @param isAdmin 管理者フラグ（true: 管理者、false: 一般社員）
+     * @return 該当するユーザーリスト
+     */
+    Iterable<User> findByIsAdmin(boolean isAdmin);
+}

--- a/output_system/backend/src/main/resources/db/migration/V1__init.sql
+++ b/output_system/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,41 +1,51 @@
 -- V1: 初期スキーマ作成
 -- PaaS管理ポータルの基本テーブルを定義する
+-- db.mdのテーブル定義に準拠（BIGSERIALサロゲートキー使用）
 
--- ユーザーテーブル: システム利用者の基本情報
+-- ユーザーテーブル: システム利用者（社員）の基本情報
+-- KeyCloakで認証された社員をDBで管理するためのテーブル
 CREATE TABLE IF NOT EXISTS users (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    -- KeyCloakのサブジェクト識別子（一意）
-    keycloak_id VARCHAR(255) NOT NULL UNIQUE,
-    -- メールアドレス（ログインID）
-    email VARCHAR(255) NOT NULL UNIQUE,
-    -- 表示名
-    display_name VARCHAR(255) NOT NULL,
-    -- ロール: 'user' または 'admin'
-    role VARCHAR(50) NOT NULL DEFAULT 'user',
-    -- 作成日時
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    -- 更新日時
-    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+    -- サロゲートキー（自動採番）
+    id BIGSERIAL PRIMARY KEY,
+    -- 社員ID（一意。例: E001, E002）
+    employee_id VARCHAR(50) NOT NULL UNIQUE,
+    -- 氏名
+    name VARCHAR(100) NOT NULL,
+    -- メールアドレス（KeyCloakと対応）
+    email VARCHAR(255) NOT NULL,
+    -- 部署名
+    department VARCHAR(100),
+    -- 役職
+    position VARCHAR(100),
+    -- 管理者フラグ（trueの場合、管理者権限を持つ）
+    is_admin BOOLEAN NOT NULL DEFAULT false,
+    -- レコード作成日時
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- レコード最終更新日時
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
 
 -- cloud_accessテーブル: ユーザーのクラウドサービスへのアクセス権管理
+-- AWSs・GCP・Azureのアクセス許可状況を管理する
 CREATE TABLE IF NOT EXISTS cloud_access (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    -- アクセス権を持つユーザー（外部キー）
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-    -- クラウドサービス名（例: 'aws', 'azure', 'gcp'）
-    service_name VARCHAR(100) NOT NULL,
-    -- アクセス権の有効/無効フラグ
+    -- サロゲートキー（自動採番）
+    id BIGSERIAL PRIMARY KEY,
+    -- アクセス権を持つユーザーのID（外部キー）
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- クラウドプロバイダー名（AWS/GCP/Azure）
+    cloud_provider VARCHAR(20) NOT NULL,
+    -- アクセス権の有効/無効フラグ（trueの場合、利用可能）
     is_enabled BOOLEAN NOT NULL DEFAULT false,
-    -- 作成日時
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    -- 更新日時
-    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    -- 同一ユーザーの同一サービスへの重複登録を防ぐ
-    UNIQUE (user_id, service_name)
+    -- レコード作成日時
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- レコード最終更新日時
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    -- 同一ユーザーの同一クラウドプロバイダーへの重複登録を防ぐ複合ユニーク制約
+    CONSTRAINT uq_cloud_access_user_provider UNIQUE (user_id, cloud_provider)
 );
 
--- インデックス: ユーザー検索の高速化
-CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
-CREATE INDEX IF NOT EXISTS idx_users_keycloak_id ON users(keycloak_id);
+-- インデックス: 検索性能の向上
+-- 社員IDによる検索（ログイン時に使用）
+CREATE INDEX IF NOT EXISTS idx_users_employee_id ON users(employee_id);
+-- ユーザーIDによるcloud_access検索（一覧表示に使用）
 CREATE INDEX IF NOT EXISTS idx_cloud_access_user_id ON cloud_access(user_id);

--- a/output_system/backend/src/main/resources/db/migration/V2__seed.sql
+++ b/output_system/backend/src/main/resources/db/migration/V2__seed.sql
@@ -1,0 +1,45 @@
+-- V2: シードデータ投入
+-- 初期動作確認用のユーザーデータとクラウドアクセスデータを投入する
+-- 管理者1名 + 一般社員3名、各ユーザーにAWS/GCP/Azureのcloud_accessレコードを設定
+
+-- usersテーブルへのシードデータ投入
+-- 重複投入を防ぐため、employee_idの一致で既存レコードを確認してからINSERTする
+INSERT INTO users (employee_id, name, email, department, position, is_admin)
+VALUES
+    -- 管理者ユーザー 1名
+    -- システム管理者として全機能にアクセス可能
+    ('E001', '田中 管理太郎', 'tanaka.admin@example.com', '情報システム部', 'システム管理者', true),
+
+    -- 一般社員ユーザー 3名
+    -- 自分のクラウドアクセス状況を確認・申請する一般利用者
+    ('E002', '佐藤 花子', 'sato.hanako@example.com', '営業部', '主任', false),
+    ('E003', '鈴木 一郎', 'suzuki.ichiro@example.com', '開発部', 'エンジニア', false),
+    ('E004', '高橋 美咲', 'takahashi.misaki@example.com', '人事部', '担当', false)
+ON CONFLICT (employee_id) DO NOTHING;
+
+-- cloud_accessテーブルへのシードデータ投入
+-- 各ユーザーにAWS/GCP/Azureの3件を設定し、一部を有効/無効で混在させる
+-- 動作確認しやすいよう、管理者は全て有効、一般社員は一部のみ有効にする
+INSERT INTO cloud_access (user_id, cloud_provider, is_enabled)
+SELECT u.id, ca.cloud_provider, ca.is_enabled
+FROM users u
+CROSS JOIN (VALUES
+    -- 管理者（E001）: 全クラウドを有効
+    ('E001', 'AWS',   true),
+    ('E001', 'GCP',   true),
+    ('E001', 'Azure', true),
+    -- 佐藤さん（E002）: AWSのみ有効
+    ('E002', 'AWS',   true),
+    ('E002', 'GCP',   false),
+    ('E002', 'Azure', false),
+    -- 鈴木さん（E003）: GCPとAzureが有効
+    ('E003', 'AWS',   false),
+    ('E003', 'GCP',   true),
+    ('E003', 'Azure', true),
+    -- 高橋さん（E004）: 全て無効（申請前の状態）
+    ('E004', 'AWS',   false),
+    ('E004', 'GCP',   false),
+    ('E004', 'Azure', false)
+) AS ca(employee_id, cloud_provider, is_enabled)
+WHERE u.employee_id = ca.employee_id
+ON CONFLICT (user_id, cloud_provider) DO NOTHING;


### PR DESCRIPTION
## Summary

docker compose up 後にPostgreSQLにusers・cloud_accessテーブルが自動作成され、
管理者1名・一般社員3名のシードデータが投入された状態になる。
開発者が手動でSQLを実行することなく、動作確認可能な状態で開発を始められる。

### 実装内容

**対象PBI**: #5 PBI 1.2: DBスキーマとシードデータが自動投入される

- #14 Task 1.2.1: Flywayマイグレーション（V1__init.sql）でDBスキーマを作成する ✅
- #15 Task 1.2.2: シードデータ（V2__seed.sql）を投入する ✅
- #16 Task 1.2.3: Spring MVCのエンティティ・リポジトリを実装する ✅

### 変更ファイル

**DBマイグレーション**
- `output_system/backend/src/main/resources/db/migration/V1__init.sql` - db.md準拠の正式スキーマ定義（BIGSERIAL/employee_id/is_adminベース）
- `output_system/backend/src/main/resources/db/migration/V2__seed.sql` - 管理者1名・一般社員3名・cloud_access計12件のシードデータ

**Spring MVCエンティティ**
- `output_system/backend/src/main/java/com/example/paas/model/User.java` - usersテーブル対応エンティティ（@OneToMany）
- `output_system/backend/src/main/java/com/example/paas/model/CloudAccess.java` - cloud_accessテーブル対応エンティティ（@ManyToOne）

**リポジトリ**
- `output_system/backend/src/main/java/com/example/paas/repository/UserRepository.java` - findByEmployeeId, findByEmail等
- `output_system/backend/src/main/java/com/example/paas/repository/CloudAccessRepository.java` - findByUserId, findByUserIdAndCloudProvider等

## Test Plan

- [ ] usersテーブルがdb.mdの定義通りに作成される（BIGSERIAL PK, employee_id UNIQUE NOT NULL, is_admin等）
- [ ] cloud_accessテーブルがdb.mdの定義通りに作成される
- [ ] cloud_access(user_id, cloud_provider)の複合ユニーク制約が定義されている
- [ ] 管理者ユーザー1名（E001, is_admin=true）がシードデータとして投入される
- [ ] 一般社員ユーザー3名（E002-E004, is_admin=false）がシードデータとして投入される
- [ ] 各ユーザーにAWS/GCP/Azureのcloud_accessレコード（計12件）が存在する

## Related Issues

- Closes #5

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)