### PR TITLE
[一般社員Cloud利用状況確認] 実装完了

### DIFF
--- a/ai_generated/HANDOVER.md
+++ b/ai_generated/HANDOVER.md
@@ -90,3 +90,4 @@ docker compose up -d
 - PBI #7: ロールに応じた画面遷移とログアウト（withAuth middleware、ロール別リダイレクト、共通ヘッダー）
 - PBI #8: 管理者がユーザー一覧を表示・検索できる（REST API + BFFプロキシ + ユーザー一覧画面）
 - PBI #9: 管理者がCloud利用可否を付与・剥奪できる（ユーザー詳細画面 + Cloud利用可否更新API + KeyCloak Admin APIロール同期）
+- PBI #10: 一般社員が自分のCloud利用状況を確認できる（GET /api/users/me + GET /api/users/me/cloud-access + マイアクセス画面カード表示）

--- a/output_system/backend/src/main/java/com/example/paas/controller/MeController.java
+++ b/output_system/backend/src/main/java/com/example/paas/controller/MeController.java
@@ -1,0 +1,160 @@
+package com.example.paas.controller;
+
+import com.example.paas.dto.CloudAccessResponse;
+import com.example.paas.dto.UserResponse;
+import com.example.paas.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 認証ユーザー自身の情報APIコントローラー
+ *
+ * <p>ログイン中のユーザーが自分自身の情報を取得するためのREST Controllerクラス。
+ * api.mdのOpenAPI定義に従ってエンドポイントを実装する。</p>
+ *
+ * <p>実装するエンドポイント:</p>
+ * <ul>
+ *   <li>GET /api/users/me - 自分のユーザー情報取得（全ユーザーがアクセス可能）</li>
+ *   <li>GET /api/users/me/cloud-access - 自分のCloud利用可否取得（全ユーザーがアクセス可能）</li>
+ * </ul>
+ *
+ * <p>ルーティング競合の回避:
+ * /api/users/{id}（UserController）と /api/users/me が競合する可能性があるが、
+ * Springは固定パスセグメント（"me"）をパスパラメータ（{id}）より優先するため、
+ * このControllerを別クラスに分けることで正しくルーティングされる。
+ * 詳細: https://docs.spring.io/spring-framework/docs/current/reference/html/web.html#mvc-ann-requestmapping-uri-templates</p>
+ *
+ * <p>認証:
+ * OAuth2 JWTトークン必須（SecurityConfig.javaで制御）。
+ * JWTペイロードの "email" クレームでDBユーザーを特定する。
+ * これにより一般社員・管理者両方がアクセスできる。</p>
+ */
+@RestController
+@RequestMapping("/api/users/me")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "users", description = "ユーザー管理API")
+@SecurityRequirement(name = "bearerAuth")
+public class MeController {
+
+    /**
+     * ユーザーサービス（コンストラクタインジェクション）
+     */
+    private final UserService userService;
+
+    /**
+     * 認証ユーザー自身のユーザー情報を取得する
+     *
+     * <p>GET /api/users/me に対応するエンドポイント。
+     * JWTトークンの "email" クレームを使ってDBからユーザー情報を取得する。
+     * 管理者・一般社員どちらもアクセス可能。</p>
+     *
+     * <p>JWTクレームからのユーザー特定フロー:</p>
+     * <ol>
+     *   <li>Spring Securityが自動的にJWTをパース・検証する</li>
+     *   <li>@AuthenticationPrincipal Jwt でJWTオブジェクトを取得する</li>
+     *   <li>JWTの "email" クレームでDBのユーザーを検索する</li>
+     *   <li>ユーザーが見つからない場合は404を返す</li>
+     * </ol>
+     *
+     * @param jwt Spring SecurityがパースしたJWTトークン（認証済みユーザーのクレームを含む）
+     * @return 認証ユーザー自身のユーザー情報（CloudAccess付き）のResponseEntity
+     */
+    @GetMapping
+    @Operation(
+        summary = "自分のユーザー情報取得",
+        description = "認証ユーザー自身の情報（社員ID・氏名・部署・CloudAccess）を取得する"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "自分のユーザー情報",
+            content = @Content(
+                mediaType = "application/json",
+                schema = @Schema(implementation = UserResponse.class)
+            )
+        ),
+        @ApiResponse(responseCode = "401", description = "未認証"),
+        @ApiResponse(responseCode = "404", description = "ユーザー不在")
+    })
+    public ResponseEntity<UserResponse> getMe(
+            @AuthenticationPrincipal Jwt jwt) {
+
+        // JWTの "email" クレームを取得する
+        // KeyCloakのJWTには "email" クレームが含まれている
+        String email = jwt.getClaimAsString("email");
+        log.info("GET /api/users/me - 自分のユーザー情報取得リクエスト: email={}", email);
+
+        // メールアドレスでDBユーザーを検索する
+        UserResponse user = userService.findByEmail(email);
+
+        log.info("GET /api/users/me - ユーザー情報取得完了: employeeId={}", user.getEmployeeId());
+        return ResponseEntity.ok(user);
+    }
+
+    /**
+     * 認証ユーザー自身のCloud利用可否を取得する
+     *
+     * <p>GET /api/users/me/cloud-access に対応するエンドポイント。
+     * JWTトークンの "email" クレームを使ってDBからCloudAccess情報を取得する。
+     * 管理者・一般社員どちらもアクセス可能。</p>
+     *
+     * <p>レスポンス例:</p>
+     * <pre>
+     * [
+     *   { "id": 1, "cloudProvider": "AWS", "isEnabled": true },
+     *   { "id": 2, "cloudProvider": "GCP", "isEnabled": false },
+     *   { "id": 3, "cloudProvider": "Azure", "isEnabled": true }
+     * ]
+     * </pre>
+     *
+     * @param jwt Spring SecurityがパースしたJWTトークン（認証済みユーザーのクレームを含む）
+     * @return 認証ユーザー自身のCloudAccessリスト（AWS/GCP/Azure各1件）のResponseEntity
+     */
+    @GetMapping("/cloud-access")
+    @Operation(
+        summary = "自分のCloud利用可否取得",
+        description = "認証ユーザー自身のAWS/GCP/AzureのCloud利用可否を取得する"
+    )
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "自分のCloud利用可否",
+            content = @Content(
+                mediaType = "application/json",
+                array = @ArraySchema(schema = @Schema(implementation = CloudAccessResponse.class))
+            )
+        ),
+        @ApiResponse(responseCode = "401", description = "未認証"),
+        @ApiResponse(responseCode = "404", description = "ユーザー不在")
+    })
+    public ResponseEntity<List<CloudAccessResponse>> getMeCloudAccess(
+            @AuthenticationPrincipal Jwt jwt) {
+
+        // JWTの "email" クレームを取得する
+        String email = jwt.getClaimAsString("email");
+        log.info("GET /api/users/me/cloud-access - 自分のCloud利用可否取得リクエスト: email={}", email);
+
+        // メールアドレスでDBユーザーを検索し、CloudAccess情報を取得する
+        List<CloudAccessResponse> cloudAccess = userService.findCloudAccessByEmail(email);
+
+        log.info("GET /api/users/me/cloud-access - Cloud利用可否取得完了: email={}, 件数={}", email, cloudAccess.size());
+        return ResponseEntity.ok(cloudAccess);
+    }
+}

--- a/output_system/backend/src/main/java/com/example/paas/service/UserService.java
+++ b/output_system/backend/src/main/java/com/example/paas/service/UserService.java
@@ -1,5 +1,6 @@
 package com.example.paas.service;
 
+import com.example.paas.dto.CloudAccessResponse;
 import com.example.paas.dto.CloudAccessUpdateRequest;
 import com.example.paas.dto.UserResponse;
 import com.example.paas.model.CloudAccess;
@@ -128,6 +129,62 @@ public class UserService {
 
         // UserエンティティをUserResponse DTOに変換して返す
         return UserResponse.from(user);
+    }
+
+    /**
+     * メールアドレスでユーザーをcloudAccess情報付きで取得する
+     *
+     * <p>GET /api/users/me で使用する。
+     * JWTの "email" クレームを使ってDBユーザーを特定するために使用する。
+     * ユーザーが存在しない場合は404 Not Foundをスローする。</p>
+     *
+     * @param email 検索するメールアドレス（JWTの "email" クレームから取得）
+     * @return ユーザー情報のUserResponse（cloudAccess付き）
+     * @throws ResponseStatusException ユーザーが存在しない場合（404）
+     */
+    public UserResponse findByEmail(String email) {
+        log.debug("メールアドレスでユーザー取得を開始する: email={}", email);
+
+        // メールアドレスでユーザーを検索する
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.warn("ユーザーが見つからない: email={}", email);
+                    return new ResponseStatusException(HttpStatus.NOT_FOUND,
+                            "ユーザーが見つかりません: email=" + email);
+                });
+
+        // cloudAccessesを一括ロード（N+1問題回避）
+        // findByEmail はcloudAccessesをEager Loadしないため、IDで再取得する
+        User userWithCloudAccesses = userRepository.findByIdWithCloudAccesses(user.getId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "ユーザーが見つかりません: email=" + email));
+
+        log.debug("メールアドレスでユーザー取得完了: email={}, employeeId={}", email, userWithCloudAccesses.getEmployeeId());
+
+        return UserResponse.from(userWithCloudAccesses);
+    }
+
+    /**
+     * メールアドレスでユーザーのCloud利用可否リストを取得する
+     *
+     * <p>GET /api/users/me/cloud-access で使用する。
+     * JWTの "email" クレームを使ってDBユーザーを特定し、そのCloudAccess情報を返す。
+     * ユーザーが存在しない場合は404 Not Foundをスローする。</p>
+     *
+     * @param email 検索するメールアドレス（JWTの "email" クレームから取得）
+     * @return CloudAccessResponseのリスト（AWS/GCP/Azure各1件）
+     * @throws ResponseStatusException ユーザーが存在しない場合（404）
+     */
+    public List<CloudAccessResponse> findCloudAccessByEmail(String email) {
+        log.debug("メールアドレスでCloud利用可否取得を開始する: email={}", email);
+
+        // findByEmailを利用してUserResponseを取得し、その中のcloudAccessリストを返す
+        // cloudAccess情報を含むUserResponseを取得するためfindByEmailを再利用する
+        UserResponse userResponse = findByEmail(email);
+
+        log.debug("メールアドレスでCloud利用可否取得完了: email={}, 件数={}", email, userResponse.getCloudAccess().size());
+
+        return userResponse.getCloudAccess();
     }
 
     /**

--- a/output_system/backend/src/test/java/com/example/paas/controller/MeControllerTest.java
+++ b/output_system/backend/src/test/java/com/example/paas/controller/MeControllerTest.java
@@ -1,0 +1,270 @@
+package com.example.paas.controller;
+
+import com.example.paas.dto.CloudAccessResponse;
+import com.example.paas.dto.UserResponse;
+import com.example.paas.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * MeControllerのユニットテスト
+ *
+ * <p>このテストクラスでは認証ユーザー自身の情報を取得するAPIをテストする。
+ * @WebMvcTest を使用して、サーブレットコンテキストのみをロードし、
+ * UserServiceはMockitoでモック化する。</p>
+ *
+ * <p>JWT認証のシミュレーション:
+ * Spring Security Testの {@code jwt()} ポストプロセッサーを使用して、
+ * JWTトークンをモック化する。これにより実際のKeyCloak通信なしに
+ * 認証済みリクエストのテストができる。</p>
+ *
+ * <p>テスト対象のエンドポイント:</p>
+ * <ul>
+ *   <li>GET /api/users/me - 自分のユーザー情報取得</li>
+ *   <li>GET /api/users/me/cloud-access - 自分のCloud利用可否取得</li>
+ * </ul>
+ */
+@WebMvcTest(MeController.class)
+@DisplayName("MeController テスト")
+class MeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    /** テスト用ユーザーレスポンス（一般社員） */
+    private UserResponse generalUserResponse;
+    /** テスト用CloudAccessレスポンスリスト */
+    private List<CloudAccessResponse> cloudAccessResponses;
+
+    /**
+     * テスト前のセットアップ
+     *
+     * <p>各テストで共通して使用するテストデータを初期化する。</p>
+     */
+    @BeforeEach
+    void setUp() {
+        // CloudAccessレスポンスの準備（AWS有効, GCP無効, Azure有効）
+        cloudAccessResponses = List.of(
+            CloudAccessResponse.builder()
+                .id(1L)
+                .cloudProvider("AWS")
+                .isEnabled(true)
+                .build(),
+            CloudAccessResponse.builder()
+                .id(2L)
+                .cloudProvider("GCP")
+                .isEnabled(false)
+                .build(),
+            CloudAccessResponse.builder()
+                .id(3L)
+                .cloudProvider("Azure")
+                .isEnabled(true)
+                .build()
+        );
+
+        // 一般社員ユーザーレスポンスの準備
+        generalUserResponse = UserResponse.builder()
+            .id(2L)
+            .employeeId("E002")
+            .name("佐藤 花子")
+            .email("sato.hanako@example.com")
+            .department("営業部")
+            .position("主任")
+            .isAdmin(false)
+            .cloudAccess(cloudAccessResponses)
+            .build();
+    }
+
+    // ========================================================================
+    // GET /api/users/me テスト
+    // ========================================================================
+
+    /**
+     * 【テスト対象】GET /api/users/me
+     * 【テスト内容】認証済みユーザーが自分の情報を取得した場合
+     * 【期待結果】JWTのemailクレームでユーザーを特定し、ユーザー情報が200で返ること
+     *
+     * 【前提条件】
+     * - JWTにemail="sato.hanako@example.com"のクレームが含まれている
+     * - DBにそのメールアドレスのユーザーが存在する
+     */
+    @Test
+    @DisplayName("should return my user info when authenticated")
+    void getMe_shouldReturnMyUserInfo_whenAuthenticated() throws Exception {
+        // Arrange: userService.findByEmail のモック設定
+        when(userService.findByEmail("sato.hanako@example.com")).thenReturn(generalUserResponse);
+
+        // Act & Assert: JWTトークンをモックしてリクエストを実行
+        mockMvc.perform(get("/api/users/me")
+                .with(jwt().jwt(builder -> builder
+                    .subject("user-subject-id")
+                    .claim("email", "sato.hanako@example.com")
+                    .issuedAt(Instant.now())
+                    .expiresAt(Instant.now().plusSeconds(3600))
+                ))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.id").value(2))
+            .andExpect(jsonPath("$.employeeId").value("E002"))
+            .andExpect(jsonPath("$.name").value("佐藤 花子"))
+            .andExpect(jsonPath("$.email").value("sato.hanako@example.com"))
+            .andExpect(jsonPath("$.department").value("営業部"))
+            .andExpect(jsonPath("$.position").value("主任"))
+            .andExpect(jsonPath("$.admin").value(false))
+            .andExpect(jsonPath("$.cloudAccess", hasSize(3)));
+
+        verify(userService, times(1)).findByEmail("sato.hanako@example.com");
+    }
+
+    /**
+     * 【テスト対象】GET /api/users/me
+     * 【テスト内容】JWTのemailクレームに対応するユーザーがDBに存在しない場合
+     * 【期待結果】404 Not Foundが返ること
+     */
+    @Test
+    @DisplayName("should return 404 when user not found by email")
+    void getMe_shouldReturn404_whenUserNotFoundByEmail() throws Exception {
+        // Arrange: findByEmailが404をスローするようにモック設定
+        when(userService.findByEmail("unknown@example.com"))
+            .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "ユーザーが見つかりません"));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/users/me")
+                .with(jwt().jwt(builder -> builder
+                    .subject("unknown-subject")
+                    .claim("email", "unknown@example.com")
+                ))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+
+        verify(userService, times(1)).findByEmail("unknown@example.com");
+    }
+
+    /**
+     * 【テスト対象】GET /api/users/me
+     * 【テスト内容】未認証ユーザーがアクセスした場合
+     * 【期待結果】401 Unauthorizedが返ること
+     */
+    @Test
+    @DisplayName("should return 401 when not authenticated")
+    void getMe_shouldReturn401_whenNotAuthenticated() throws Exception {
+        // Act & Assert（JWTなしでアクセス）
+        mockMvc.perform(get("/api/users/me")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
+
+        // Serviceは呼ばれないはず
+        verify(userService, never()).findByEmail(anyString());
+    }
+
+    // ========================================================================
+    // GET /api/users/me/cloud-access テスト
+    // ========================================================================
+
+    /**
+     * 【テスト対象】GET /api/users/me/cloud-access
+     * 【テスト内容】認証済みユーザーが自分のCloud利用可否を取得した場合
+     * 【期待結果】AWS/GCP/AzureのCloud利用可否リストが200で返ること
+     *
+     * 【前提条件】
+     * - JWTにemail="sato.hanako@example.com"のクレームが含まれている
+     * - DBにそのメールアドレスのユーザーが存在し、Cloud利用可否が設定されている
+     *
+     * 【期待結果の詳細】
+     * - AWS: isEnabled=true（利用可）
+     * - GCP: isEnabled=false（利用不可）
+     * - Azure: isEnabled=true（利用可）
+     */
+    @Test
+    @DisplayName("should return my cloud access list when authenticated")
+    void getMeCloudAccess_shouldReturnCloudAccessList_whenAuthenticated() throws Exception {
+        // Arrange: userService.findCloudAccessByEmail のモック設定
+        when(userService.findCloudAccessByEmail("sato.hanako@example.com"))
+            .thenReturn(cloudAccessResponses);
+
+        // Act & Assert: JWTトークンをモックしてリクエストを実行
+        mockMvc.perform(get("/api/users/me/cloud-access")
+                .with(jwt().jwt(builder -> builder
+                    .subject("user-subject-id")
+                    .claim("email", "sato.hanako@example.com")
+                ))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$", hasSize(3)))
+            .andExpect(jsonPath("$[0].cloudProvider").value("AWS"))
+            .andExpect(jsonPath("$[0].enabled").value(true))
+            .andExpect(jsonPath("$[1].cloudProvider").value("GCP"))
+            .andExpect(jsonPath("$[1].enabled").value(false))
+            .andExpect(jsonPath("$[2].cloudProvider").value("Azure"))
+            .andExpect(jsonPath("$[2].enabled").value(true));
+
+        verify(userService, times(1)).findCloudAccessByEmail("sato.hanako@example.com");
+    }
+
+    /**
+     * 【テスト対象】GET /api/users/me/cloud-access
+     * 【テスト内容】JWTのemailクレームに対応するユーザーがDBに存在しない場合
+     * 【期待結果】404 Not Foundが返ること
+     */
+    @Test
+    @DisplayName("should return 404 when user not found by email for cloud access")
+    void getMeCloudAccess_shouldReturn404_whenUserNotFound() throws Exception {
+        // Arrange: findCloudAccessByEmailが404をスローするようにモック設定
+        when(userService.findCloudAccessByEmail("unknown@example.com"))
+            .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "ユーザーが見つかりません"));
+
+        // Act & Assert
+        mockMvc.perform(get("/api/users/me/cloud-access")
+                .with(jwt().jwt(builder -> builder
+                    .subject("unknown-subject")
+                    .claim("email", "unknown@example.com")
+                ))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+
+        verify(userService, times(1)).findCloudAccessByEmail("unknown@example.com");
+    }
+
+    /**
+     * 【テスト対象】GET /api/users/me/cloud-access
+     * 【テスト内容】未認証ユーザーがアクセスした場合
+     * 【期待結果】401 Unauthorizedが返ること
+     */
+    @Test
+    @DisplayName("should return 401 when not authenticated for cloud access")
+    void getMeCloudAccess_shouldReturn401_whenNotAuthenticated() throws Exception {
+        // Act & Assert（JWTなしでアクセス）
+        mockMvc.perform(get("/api/users/me/cloud-access")
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnauthorized());
+
+        // Serviceは呼ばれないはず
+        verify(userService, never()).findCloudAccessByEmail(anyString());
+    }
+}

--- a/output_system/backend/src/test/java/com/example/paas/service/UserServiceTest.java
+++ b/output_system/backend/src/test/java/com/example/paas/service/UserServiceTest.java
@@ -1,8 +1,10 @@
 package com.example.paas.service;
 
+import com.example.paas.dto.CloudAccessResponse;
 import com.example.paas.dto.UserResponse;
 import com.example.paas.model.CloudAccess;
 import com.example.paas.model.User;
+import com.example.paas.repository.CloudAccessRepository;
 import com.example.paas.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -11,11 +13,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -37,6 +44,9 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private CloudAccessRepository cloudAccessRepository;
 
     @InjectMocks
     private UserService userService;
@@ -347,5 +357,140 @@ class UserServiceTest {
         assertThat(result).hasSize(2);
         verify(userRepository, times(1)).findAllWithCloudAccesses();
         verify(userRepository, never()).searchByKeywordWithCloudAccesses(anyString());
+    }
+
+    // ========================================================================
+    // findByEmail(email) テスト
+    // ========================================================================
+
+    /**
+     * 【テスト対象】UserService#findByEmail
+     * 【テスト内容】存在するメールアドレスでユーザーを検索した場合
+     * 【期待結果】ユーザー情報（cloudAccess付き）がUserResponseとして返ること
+     *
+     * 【前提条件】
+     * - findByEmail でユーザーが見つかる
+     * - findByIdWithCloudAccesses でcloudAccesses付きユーザーが取得できる
+     */
+    @Test
+    @DisplayName("should return user with cloud access when email exists")
+    void findByEmail_shouldReturnUser_whenEmailExists() {
+        // Arrange
+        when(userRepository.findByEmail("sato.hanako@example.com")).thenReturn(Optional.of(generalUser));
+        when(userRepository.findByIdWithCloudAccesses(2L)).thenReturn(Optional.of(generalUser));
+
+        // Act
+        UserResponse result = userService.findByEmail("sato.hanako@example.com");
+
+        // Assert
+        assertThat(result.getEmployeeId()).isEqualTo("E002");
+        assertThat(result.getName()).isEqualTo("佐藤 花子");
+        assertThat(result.getEmail()).isEqualTo("sato.hanako@example.com");
+        assertThat(result.isAdmin()).isFalse();
+        assertThat(result.getCloudAccess()).hasSize(3);
+
+        verify(userRepository, times(1)).findByEmail("sato.hanako@example.com");
+        verify(userRepository, times(1)).findByIdWithCloudAccesses(2L);
+    }
+
+    /**
+     * 【テスト対象】UserService#findByEmail
+     * 【テスト内容】管理者ユーザーのメールアドレスで検索した場合
+     * 【期待結果】管理者フラグ=trueでユーザー情報が返ること
+     */
+    @Test
+    @DisplayName("should return admin user when admin email is given")
+    void findByEmail_shouldReturnAdminUser_whenAdminEmailIsGiven() {
+        // Arrange
+        when(userRepository.findByEmail("tanaka.admin@example.com")).thenReturn(Optional.of(adminUser));
+        when(userRepository.findByIdWithCloudAccesses(1L)).thenReturn(Optional.of(adminUser));
+
+        // Act
+        UserResponse result = userService.findByEmail("tanaka.admin@example.com");
+
+        // Assert
+        assertThat(result.getEmployeeId()).isEqualTo("E001");
+        assertThat(result.isAdmin()).isTrue();
+        assertThat(result.getCloudAccess()).hasSize(3);
+        // CloudAccessの内容を検証
+        assertThat(result.getCloudAccess().get(0).getCloudProvider()).isEqualTo("AWS");
+        assertThat(result.getCloudAccess().get(0).isEnabled()).isTrue();
+        assertThat(result.getCloudAccess().get(1).getCloudProvider()).isEqualTo("GCP");
+        assertThat(result.getCloudAccess().get(1).isEnabled()).isFalse();
+        assertThat(result.getCloudAccess().get(2).getCloudProvider()).isEqualTo("Azure");
+        assertThat(result.getCloudAccess().get(2).isEnabled()).isTrue();
+    }
+
+    /**
+     * 【テスト対象】UserService#findByEmail
+     * 【テスト内容】存在しないメールアドレスでユーザーを検索した場合
+     * 【期待結果】ResponseStatusException（404 NOT_FOUND）がスローされること
+     */
+    @Test
+    @DisplayName("should throw 404 when email does not exist")
+    void findByEmail_shouldThrow404_whenEmailNotFound() {
+        // Arrange
+        when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> userService.findByEmail("unknown@example.com"))
+            .isInstanceOf(ResponseStatusException.class)
+            .satisfies(ex -> {
+                ResponseStatusException rse = (ResponseStatusException) ex;
+                assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            });
+
+        verify(userRepository, times(1)).findByEmail("unknown@example.com");
+        // findByIdWithCloudAccesses は呼ばれないはず（findByEmailが空を返したため）
+        verify(userRepository, never()).findByIdWithCloudAccesses(anyLong());
+    }
+
+    // ========================================================================
+    // findCloudAccessByEmail(email) テスト
+    // ========================================================================
+
+    /**
+     * 【テスト対象】UserService#findCloudAccessByEmail
+     * 【テスト内容】存在するメールアドレスでCloud利用可否を取得した場合
+     * 【期待結果】AWS/GCP/AzureのCloudAccessResponseリストが返ること
+     */
+    @Test
+    @DisplayName("should return cloud access list when email exists")
+    void findCloudAccessByEmail_shouldReturnCloudAccessList_whenEmailExists() {
+        // Arrange
+        when(userRepository.findByEmail("sato.hanako@example.com")).thenReturn(Optional.of(generalUser));
+        when(userRepository.findByIdWithCloudAccesses(2L)).thenReturn(Optional.of(generalUser));
+
+        // Act
+        List<CloudAccessResponse> result = userService.findCloudAccessByEmail("sato.hanako@example.com");
+
+        // Assert: 3件（AWS/GCP/Azure）が返ること
+        assertThat(result).hasSize(3);
+        // 各プロバイダーの存在確認（順序は実装依存のため個別検証）
+        assertThat(result).anyMatch(ca -> "AWS".equals(ca.getCloudProvider()));
+        assertThat(result).anyMatch(ca -> "GCP".equals(ca.getCloudProvider()));
+        assertThat(result).anyMatch(ca -> "Azure".equals(ca.getCloudProvider()));
+    }
+
+    /**
+     * 【テスト対象】UserService#findCloudAccessByEmail
+     * 【テスト内容】存在しないメールアドレスでCloud利用可否を取得しようとした場合
+     * 【期待結果】ResponseStatusException（404 NOT_FOUND）がスローされること
+     */
+    @Test
+    @DisplayName("should throw 404 when email does not exist for cloud access")
+    void findCloudAccessByEmail_shouldThrow404_whenEmailNotFound() {
+        // Arrange
+        when(userRepository.findByEmail("unknown@example.com")).thenReturn(Optional.empty());
+
+        // Act & Assert
+        assertThatThrownBy(() -> userService.findCloudAccessByEmail("unknown@example.com"))
+            .isInstanceOf(ResponseStatusException.class)
+            .satisfies(ex -> {
+                ResponseStatusException rse = (ResponseStatusException) ex;
+                assertThat(rse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+            });
+
+        verify(userRepository, times(1)).findByEmail("unknown@example.com");
     }
 }

--- a/output_system/frontend/.eslintrc.json
+++ b/output_system/frontend/.eslintrc.json
@@ -1,0 +1,1 @@
+{"extends": "next/core-web-vitals"}

--- a/output_system/frontend/src/app/my-access/page.tsx
+++ b/output_system/frontend/src/app/my-access/page.tsx
@@ -9,53 +9,119 @@
  * - GCP: 利用可 / 利用不可
  * - Azure: 利用可 / 利用不可
  *
- * Server Componentとして実装し、バックエンドAPIからデータを取得する（PBI #8で実装予定）。
+ * Server Componentとして実装し、バックエンドAPIからデータを取得する。
+ *
+ * データ取得フロー:
+ * 1. このServer ComponentがBFFプロキシの /api/proxy/users/me/cloud-access を呼び出す
+ * 2. BFFプロキシがセッションのJWTトークンを付与してバックエンドに転送
+ * 3. バックエンドがJWTの "email" クレームでDBユーザーを特定しCloudAccessを返す
+ *
+ * 参考:
+ * - api.md: GET /api/users/me/cloud-access エンドポイント定義
+ * - screens.md: マイアクセス画面ワイヤーフレーム
+ * - Next.js Server Components: https://nextjs.org/docs/app/building-your-application/rendering/server-components
  */
 
 import { MainLayout } from "@/components/layout/main-layout";
+import { AccessStatusCard } from "@/components/my-access/access-status-card";
+import { getMyCloudAccess, type CloudAccessResponse } from "@/lib/api-client";
+
+/**
+ * サポートするクラウドプロバイダーの定義
+ *
+ * DBにデータがない場合のフォールバック表示にも使用する。
+ * 表示順はAPI定義に従いAWS→GCP→Azureの順とする。
+ */
+const SUPPORTED_CLOUD_PROVIDERS: Array<"AWS" | "GCP" | "Azure"> = ["AWS", "GCP", "Azure"];
 
 /**
  * マイアクセスページコンポーネント
  *
  * 一般社員が自分のCloud利用状況を確認するページ。
+ * Server Componentとして実装し、バックエンドAPIから直接データを取得する。
  * ヘッダー付きのMainLayoutを使用する。
+ *
+ * エラーハンドリング:
+ * - APIエラー（ネットワーク障害、401、500等）の場合はエラーメッセージを表示する
+ * - DBにCloudAccessデータがない場合は「利用不可」として表示する
  */
-export default function MyAccessPage() {
+export default async function MyAccessPage() {
+  // Cloud利用可否データを取得する
+  // エラーが発生した場合はキャッチしてエラー表示に切り替える
+  let cloudAccessList: CloudAccessResponse[] = [];
+  let fetchError: string | null = null;
+
+  try {
+    // BFFプロキシ経由でバックエンドの GET /api/users/me/cloud-access を呼び出す
+    // Server ComponentからはBFFプロキシ（/api/proxy/...）へのfetchを使用する
+    cloudAccessList = await getMyCloudAccess();
+  } catch (error) {
+    // APIエラーが発生した場合はエラーメッセージを設定する
+    // ユーザーには具体的なエラー詳細ではなく、分かりやすいメッセージを表示する
+    console.error("[MyAccessPage] Cloud利用可否の取得に失敗しました:", error);
+    fetchError = "クラウドサービスのアクセス状況を取得できませんでした。時間をおいてから再度お試しください。";
+  }
+
+  /**
+   * クラウドプロバイダーに対応するCloudAccessResponseを返すヘルパー関数
+   *
+   * DBにデータが存在しないクラウドプロバイダーの場合は「利用不可」として扱う。
+   *
+   * @param provider クラウドプロバイダー名
+   * @returns CloudAccessResponse または利用不可のデフォルト値
+   */
+  function getCloudAccessForProvider(
+    provider: "AWS" | "GCP" | "Azure"
+  ): { cloudProvider: "AWS" | "GCP" | "Azure"; isEnabled: boolean } {
+    // APIから取得したリストから対応するプロバイダーのデータを検索する
+    const found = cloudAccessList.find((ca) => ca.cloudProvider === provider);
+    // 見つからない場合はデフォルト値（利用不可）を返す
+    return found ?? { cloudProvider: provider, isEnabled: false };
+  }
+
   return (
     <MainLayout>
       <div>
+        {/* ページタイトル */}
         <h2 className="text-2xl font-bold text-gray-900">マイアクセス状況</h2>
         <p className="mt-2 text-sm text-gray-600">
           現在のクラウドサービスへのアクセス権を確認できます。
         </p>
 
-        {/*
-          Cloud利用可否の表示エリア（PBI #8で実装予定）
-          screens.mdワイヤーフレームの該当部分:
-          - AWS: 利用可 / 利用不可
-          - GCP: 利用可 / 利用不可
-          - Azure: 利用可 / 利用不可
-        */}
+        {/* エラーメッセージ表示エリア */}
+        {fetchError && (
+          <div
+            className="mt-6 rounded-lg border border-red-200 bg-red-50 p-4"
+            role="alert"
+            aria-live="assertive"
+          >
+            <div className="flex items-center gap-2">
+              <span className="text-red-500 font-bold" aria-hidden="true">⚠</span>
+              <p className="text-sm text-red-700">{fetchError}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Cloud利用可否カード表示エリア */}
+        {/* screens.mdワイヤーフレームに従い、3列グリッドでカードを並べる */}
         <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
-          <div className="rounded-lg border bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-medium text-gray-900">AWS</h3>
-            <p className="mt-2 text-sm text-gray-500">
-              アクセス状況を読み込み中...
-            </p>
-          </div>
-          <div className="rounded-lg border bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-medium text-gray-900">GCP</h3>
-            <p className="mt-2 text-sm text-gray-500">
-              アクセス状況を読み込み中...
-            </p>
-          </div>
-          <div className="rounded-lg border bg-white p-6 shadow-sm">
-            <h3 className="text-lg font-medium text-gray-900">Azure</h3>
-            <p className="mt-2 text-sm text-gray-500">
-              アクセス状況を読み込み中...
-            </p>
-          </div>
+          {SUPPORTED_CLOUD_PROVIDERS.map((provider) => {
+            const accessData = getCloudAccessForProvider(provider);
+            return (
+              <AccessStatusCard
+                key={provider}
+                cloudProvider={accessData.cloudProvider}
+                isEnabled={accessData.isEnabled}
+              />
+            );
+          })}
         </div>
+
+        {/* 最終更新時刻の表示（ページ読み込み時刻） */}
+        <p className="mt-6 text-xs text-gray-400">
+          ※ このページの情報はページ読み込み時点のものです。
+          最新の状態を確認する場合はページを再読み込みしてください。
+        </p>
       </div>
     </MainLayout>
   );

--- a/output_system/frontend/src/components/my-access/access-status-card.tsx
+++ b/output_system/frontend/src/components/my-access/access-status-card.tsx
@@ -1,0 +1,131 @@
+/**
+ * CloudアクセスステータスカードコンポーネントのProps定義
+ */
+export type AccessStatusCardProps = {
+  /**
+   * クラウドプロバイダー名
+   * 表示ラベルとして使用する（例: "AWS", "GCP", "Azure"）
+   */
+  cloudProvider: "AWS" | "GCP" | "Azure";
+
+  /**
+   * アクセス権の有効/無効フラグ
+   * true: 利用可（緑表示）、false: 利用不可（グレー表示）
+   */
+  isEnabled: boolean;
+};
+
+/**
+ * CloudプロバイダーのアイコンURLを返すヘルパー関数
+ *
+ * 各クラウドプロバイダーのアイコン絵文字を返す。
+ * 将来的にSVGアイコンに差し替え可能。
+ *
+ * @param cloudProvider クラウドプロバイダー名
+ * @returns 絵文字アイコン文字列
+ */
+function getCloudProviderIcon(cloudProvider: "AWS" | "GCP" | "Azure"): string {
+  switch (cloudProvider) {
+    case "AWS":
+      // Amazon Web Servicesのアイコン（オレンジ系）
+      return "☁️";
+    case "GCP":
+      // Google Cloud Platformのアイコン（マルチカラー）
+      return "🌐";
+    case "Azure":
+      // Microsoft Azureのアイコン（青系）
+      return "🔷";
+    default:
+      return "☁️";
+  }
+}
+
+/**
+ * Cloud利用可否を表示するカードコンポーネント
+ *
+ * 一般社員向けのマイアクセス画面でCloud利用可否を1枚のカードとして表示する。
+ * screens.mdのワイヤーフレームに準拠し、以下の情報を表示する:
+ * - クラウドプロバイダー名（AWS / GCP / Azure）
+ * - 利用可否状態（利用可 / 利用不可）
+ * - 視覚的な色分け（利用可: 緑系、利用不可: グレー系）
+ *
+ * shadcn/ui Cardコンポーネントを使用して実装する。
+ * Tailwind CSSで利用可/不可の色分けを実装する。
+ *
+ * @param props AccessStatusCardProps
+ * @returns カードコンポーネント
+ *
+ * @example
+ * // 利用可の場合（緑の表示）
+ * <AccessStatusCard cloudProvider="AWS" isEnabled={true} />
+ *
+ * @example
+ * // 利用不可の場合（グレーの表示）
+ * <AccessStatusCard cloudProvider="GCP" isEnabled={false} />
+ */
+export function AccessStatusCard({ cloudProvider, isEnabled }: AccessStatusCardProps) {
+  // 利用可/不可に応じてTailwindクラスを動的に切り替える
+  // 利用可: 緑系の背景・テキスト・ボーダー
+  // 利用不可: グレー系の背景・テキスト・ボーダー
+  const cardBorderClass = isEnabled
+    ? "border-green-200"
+    : "border-gray-200";
+
+  const statusBadgeClass = isEnabled
+    ? "bg-green-100 text-green-800 border border-green-200"
+    : "bg-gray-100 text-gray-600 border border-gray-200";
+
+  const statusIconClass = isEnabled
+    ? "text-green-500"
+    : "text-gray-400";
+
+  const statusLabel = isEnabled ? "利用可" : "利用不可";
+  const statusIcon = isEnabled ? "✓" : "✕";
+  const cloudIcon = getCloudProviderIcon(cloudProvider);
+
+  return (
+    <div
+      className={`rounded-lg border bg-white p-6 shadow-sm transition-all ${cardBorderClass}`}
+      role="article"
+      aria-label={`${cloudProvider}の利用状況: ${statusLabel}`}
+    >
+      {/* カードヘッダー: クラウドアイコンとプロバイダー名 */}
+      <div className="flex items-center gap-3 mb-4">
+        <span className="text-2xl" aria-hidden="true">
+          {cloudIcon}
+        </span>
+        <h3 className="text-lg font-semibold text-gray-900">
+          {cloudProvider}
+        </h3>
+      </div>
+
+      {/* 利用可否状態バッジ */}
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium ${statusBadgeClass}`}
+          aria-live="polite"
+        >
+          {/* 利用可/不可アイコン */}
+          <span className={`font-bold text-base ${statusIconClass}`} aria-hidden="true">
+            {statusIcon}
+          </span>
+          {statusLabel}
+        </span>
+      </div>
+
+      {/* 利用可の場合にのみ表示する補足メッセージ */}
+      {isEnabled && (
+        <p className="mt-3 text-xs text-green-600">
+          このクラウドサービスにアクセスできます
+        </p>
+      )}
+
+      {/* 利用不可の場合に表示する補足メッセージ */}
+      {!isEnabled && (
+        <p className="mt-3 text-xs text-gray-500">
+          管理者にアクセス権の付与を申請してください
+        </p>
+      )}
+    </div>
+  );
+}

--- a/output_system/frontend/src/lib/api-client.ts
+++ b/output_system/frontend/src/lib/api-client.ts
@@ -210,6 +210,43 @@ export type CloudAccessUpdateRequest = {
 };
 
 /**
+ * 認証ユーザー自身のユーザー情報を取得する
+ *
+ * BFFプロキシ経由でバックエンドの GET /api/users/me を呼び出す。
+ * JWTトークンに含まれるemailクレームでDBユーザーを特定し、
+ * 自分のユーザー情報（社員ID・氏名・メール・部署・役職・CloudAccess）を返す。
+ *
+ * @returns 認証ユーザー自身のユーザー情報（CloudAccess付き）
+ * @throws {ApiError} API呼び出しに失敗した場合（401: 未認証、404: ユーザー不在等）
+ *
+ * @example
+ * const me = await getMe();
+ * console.log(me.name); // "佐藤 花子"
+ */
+export async function getMe(): Promise<UserResponse> {
+  return proxyFetch<UserResponse>("/api/proxy/users/me");
+}
+
+/**
+ * 認証ユーザー自身のCloud利用可否を取得する
+ *
+ * BFFプロキシ経由でバックエンドの GET /api/users/me/cloud-access を呼び出す。
+ * JWTトークンに含まれるemailクレームでDBユーザーを特定し、
+ * 自分のAWS/GCP/AzureのCloud利用可否リストを返す。
+ *
+ * @returns 認証ユーザー自身のCloudAccessリスト（AWS/GCP/Azure各1件）
+ * @throws {ApiError} API呼び出しに失敗した場合（401: 未認証、404: ユーザー不在等）
+ *
+ * @example
+ * const cloudAccess = await getMyCloudAccess();
+ * const awsAccess = cloudAccess.find(ca => ca.cloudProvider === "AWS");
+ * console.log(awsAccess?.isEnabled); // true or false
+ */
+export async function getMyCloudAccess(): Promise<CloudAccessResponse[]> {
+  return proxyFetch<CloudAccessResponse[]>("/api/proxy/users/me/cloud-access");
+}
+
+/**
  * Cloud利用可否を更新する
  *
  * BFFプロキシ経由でバックエンドの PUT /api/users/{id}/cloud-access を呼び出す。


### PR DESCRIPTION
## Summary

一般社員が自分のCloud利用可否状況（AWS/GCP/Azure）をマイアクセス画面で確認できるようにする。
問い合わせなく自己確認できることで、管理者への問い合わせを削減する。

### 実装内容

**対象PBI**: #10 PBI 3.3: 一般社員が自分のCloud利用状況を確認できる

- #28 Task 3.3.1: バックエンドの自分の情報・Cloud利用可否取得APIを実装する ✅
- #29 Task 3.3.2: マイアクセス画面を実装する ✅

### 変更ファイル

**バックエンド（Spring Boot）:**
- `output_system/backend/src/main/java/com/example/paas/controller/MeController.java` （新規）
  - GET /api/users/me - 認証ユーザー自身のユーザー情報取得
  - GET /api/users/me/cloud-access - 認証ユーザー自身のCloud利用可否取得
- `output_system/backend/src/main/java/com/example/paas/service/UserService.java`
  - findByEmail() メソッド追加
  - findCloudAccessByEmail() メソッド追加
- `output_system/backend/src/test/java/com/example/paas/controller/MeControllerTest.java` （新規）
- `output_system/backend/src/test/java/com/example/paas/service/UserServiceTest.java`

**フロントエンド（Next.js）:**
- `output_system/frontend/src/components/my-access/access-status-card.tsx` （新規）
  - Cloud利用可否カードコンポーネント（利用可: 緑、利用不可: グレーの色分け）
- `output_system/frontend/src/app/my-access/page.tsx`
  - Server ComponentでBFFプロキシ経由のAPIデータ取得実装
  - AWS/GCP/Azureを3列グリッドのカード形式で表示
  - APIエラー時のフォールバック表示対応
- `output_system/frontend/src/lib/api-client.ts`
  - getMe() 関数追加
  - getMyCloudAccess() 関数追加

## Test Plan

- [ ] マイアクセス画面（/my-access）でAWS/GCP/Azureの利用可否が表示される
- [ ] 利用可（isEnabled=true）は緑色で「✓ 利用可」と表示される
- [ ] 利用不可（isEnabled=false）はグレーで「✕ 利用不可」と表示される
- [ ] バックエンドAPI（GET /api/users/me）が認証ユーザー自身の情報を返す
- [ ] バックエンドAPI（GET /api/users/me/cloud-access）が認証ユーザーのCloud利用可否を返す
- [ ] BFFプロキシ（/api/proxy/users/me, /api/proxy/users/me/cloud-access）経由でアクセスできる
- [ ] 未認証アクセス時に401が返る

## Screenshots

| 画面名 | スクリーンショット |
|--------|-------------------|
| ログイン画面 | ![ログイン画面](https://github.com/okegawaatclink/gaido-paas/raw/ccd3916efde660c7d6833e2b27d2b426c4f02cd1/ai_generated/screenshots/task-29_login.png) |

## Related Issues

- Closes #10

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)